### PR TITLE
feat: bump concurrency to 50

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -20,8 +20,8 @@ processes = []
   script_checks = []
 
   [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
+    hard_limit = 50
+    soft_limit = 45
     type = "connections"
 
   [[services.ports]]


### PR DESCRIPTION
refer to:
https://community.fly.io/t/is-there-a-concurrent-websocket-connections-limit/3229